### PR TITLE
classify whole class name /w modules instead of just class name in grabbers

### DIFF
--- a/lib/ids_please/grabbers.rb
+++ b/lib/ids_please/grabbers.rb
@@ -19,8 +19,7 @@ class IdsPlease
     end
 
     def self.by_symbol(sym)
-      klass_name = "#{sym.to_s[0].upcase}#{sym.to_s[1..-1]}"
-      self.const_get(klass_name)
+      "IdsPlease::Grabbers::#{sym.to_s.capitalize}".classify
     end
 
   end

--- a/lib/ids_please/grabbers.rb
+++ b/lib/ids_please/grabbers.rb
@@ -19,7 +19,7 @@ class IdsPlease
     end
 
     def self.by_symbol(sym)
-      "IdsPlease::Grabbers::#{sym.to_s.capitalize}".constantize
+      Kernel.const_get("IdsPlease::Grabbers::#{sym.to_s.capitalize}")
     end
 
   end

--- a/lib/ids_please/grabbers.rb
+++ b/lib/ids_please/grabbers.rb
@@ -19,7 +19,7 @@ class IdsPlease
     end
 
     def self.by_symbol(sym)
-      "IdsPlease::Grabbers::#{sym.to_s.capitalize}".classify
+      "IdsPlease::Grabbers::#{sym.to_s.capitalize}".constantize
     end
 
   end

--- a/lib/ids_please/grabbers/twitter.rb
+++ b/lib/ids_please/grabbers/twitter.rb
@@ -1,28 +1,23 @@
-class IdsPlease
-  module Grabbers
-    class Twitter < IdsPlease::Grabbers::Base
-
-      def grab_link
-        @page_source ||= open(link).read
-        @network_id  = @page_source.scan(/data-user-id="(\d+)"/).flatten.first
-        @avatar = @page_source.scan(/ProfileAvatar-image " src="([^"]+)"/).flatten.first
-        @display_name = @page_source.scan(/ProfileHeaderCard-nameLink[^>]+>([^<]+)</).flatten.first
-        @username = @page_source.scan(/<title>[^\(]+\(@([^\)]+)\)/).flatten.first
-        @data = {}
-        {
-          description: @page_source.scan(/ProfileHeaderCard-bio[^>]+>([^<]+)</).flatten.first.encode('utf-8'),
-          location: @page_source.scan(/ProfileHeaderCard-locationText[^>]+>([^<]+)</).flatten.first.encode('utf-8'),
-          join_date: @page_source.scan(/ProfileHeaderCard-joinDateText[^>]+>([^<]+)</).flatten.first.encode('utf-8'),
-        }.each do |k, v|
-          next if v.nil? || v == ''
-          @data[k] = CGI.unescapeHTML(v)
-        end
-        self
-      rescue => e
-        p e
-        return self
-      end
-
+class IdsPlease::Grabbers::Twitter < IdsPlease::Grabbers::Base
+  
+  def grab_link
+    @page_source ||= open(link).read
+    @network_id  = @page_source.scan(/data-user-id="(\d+)"/).flatten.first
+    @avatar = @page_source.scan(/ProfileAvatar-image " src="([^"]+)"/).flatten.first
+    @display_name = @page_source.scan(/ProfileHeaderCard-nameLink[^>]+>([^<]+)</).flatten.first
+    @username = @page_source.scan(/<title>[^\(]+\(@([^\)]+)\)/).flatten.first
+    @data = {}
+    {
+      description: @page_source.scan(/ProfileHeaderCard-bio[^>]+>([^<]+)</).flatten.first.encode('utf-8'),
+      location: @page_source.scan(/ProfileHeaderCard-locationText[^>]+>([^<]+)</).flatten.first.encode('utf-8'),
+      join_date: @page_source.scan(/ProfileHeaderCard-joinDateText[^>]+>([^<]+)</).flatten.first.encode('utf-8'),
+    }.each do |k, v|
+      next if v.nil? || v == ''
+      @data[k] = CGI.unescapeHTML(v)
     end
+    self
+  rescue => e
+    p e
+    return self
   end
 end


### PR DESCRIPTION
Or else `by_symbol(:twitter)` returns module `Twitter`, which has nothing to do with IdsPlease.