### PR TITLE
Avoid undefined methods for nil class

### DIFF
--- a/lib/ids_please/grabbers/facebook.rb
+++ b/lib/ids_please/grabbers/facebook.rb
@@ -11,8 +11,8 @@ class IdsPlease
         @display_name = CGI.unescapeHTML(@display_name.encode('utf-8')) if @display_name
         @data = {}
         {
-          type: page_source.scan(/og:type" content="([^"]+)"/).flatten.first.encode('utf-8'),
-          description: page_source.scan(/og:description" content="([^"]+)"/).flatten.first.encode('utf-8'),
+          type: page_source.scan(/og:type" content="([^"]+)"/).flatten.first.to_s.encode('utf-8'),
+          description: page_source.scan(/og:description" content="([^"]+)"/).flatten.first.to_s.encode('utf-8'),
         }.each do |k, v|
           next if v.nil? || v == ''
           @data[k] = CGI.unescapeHTML(v).strip

--- a/lib/ids_please/grabbers/facebook.rb
+++ b/lib/ids_please/grabbers/facebook.rb
@@ -28,14 +28,14 @@ class IdsPlease
       end
 
       def likes
-        page_source.scan(/>([^"]+) <span class=".+">likes/).flatten.first.tr(',','').to_i
+        page_source.scan(/>([^"]+) <span class=".+">likes/).flatten.first.to_s.tr(',','').to_i
       rescue => e
         p e
         return nil
       end
 
       def visits
-        page_source.scan(/likes.+>([^"]+)<\/span> <span class=".+">visits/).flatten.first.tr(',','').to_i
+        page_source.scan(/likes.+>([^"]+)<\/span> <span class=".+">visits/).flatten.first.to_s.tr(',','').to_i
       rescue => e
         p e
         return nil

--- a/lib/ids_please/grabbers/google_plus.rb
+++ b/lib/ids_please/grabbers/google_plus.rb
@@ -11,8 +11,8 @@ class IdsPlease
           description: page_source.scan(/name="Description" content="([^"]+)">/).flatten.first.to_s.encode('utf-8')
         }
         @counts = {
-          followers:  page_source.scan(/">([^"]+)<\/span> followers</).flatten.first.tr(',','').to_i,
-          views: page_source.scan(/">([^"]+)<\/span> views</).flatten.first.tr(',','').to_i,
+          followers:  page_source.scan(/">([^"]+)<\/span> followers</).flatten.first.to_s.tr(',','').to_i,
+          views: page_source.scan(/">([^"]+)<\/span> views</).flatten.first.to_s.tr(',','').to_i,
         }
         self
       rescue => e

--- a/lib/ids_please/grabbers/google_plus.rb
+++ b/lib/ids_please/grabbers/google_plus.rb
@@ -8,7 +8,7 @@ class IdsPlease
         @display_name = page_source.scan(/og:title" content="([^"]+)"/).flatten.first.gsub(' - Google+','')
         @username     = '+' + page_source.scan(/&quot;https:\/\/plus.google.com\/\+(.+?)&quot;/).flatten.first
         @data = {
-          description: page_source.scan(/name="Description" content="([^"]+)">/).flatten.first.encode('utf-8')
+          description: page_source.scan(/name="Description" content="([^"]+)">/).flatten.first.to_s.encode('utf-8')
         }
         @counts = {
           followers:  page_source.scan(/">([^"]+)<\/span> followers</).flatten.first.tr(',','').to_i,

--- a/lib/ids_please/grabbers/twitter.rb
+++ b/lib/ids_please/grabbers/twitter.rb
@@ -9,9 +9,9 @@ class IdsPlease
         @username     = page_source.scan(/<title>[^\(]+\(@([^\)]+)\)/).flatten.first
         @data = {}
         {
-          description: page_source.scan(/ProfileHeaderCard-bio[^>]+>([^<]+)</).flatten.first.encode('utf-8'),
-          location: page_source.scan(/ProfileHeaderCard-locationText[^>]+>([^<]+)</).flatten.first.encode('utf-8'),
-          join_date: page_source.scan(/ProfileHeaderCard-joinDateText[^>]+>([^<]+)</).flatten.first.encode('utf-8'),
+          description: page_source.scan(/ProfileHeaderCard-bio[^>]+>([^<]+)</).flatten.first.to_s.encode('utf-8'),
+          location: page_source.scan(/ProfileHeaderCard-locationText[^>]+>([^<]+)</).flatten.first.to_s.encode('utf-8'),
+          join_date: page_source.scan(/ProfileHeaderCard-joinDateText[^>]+>([^<]+)</).flatten.first.to_s.encode('utf-8'),
         }.each do |k, v|
           next if v.nil? || v == ''
           @data[k] = CGI.unescapeHTML(v).strip

--- a/spec/ids_please/basic_spec.rb
+++ b/spec/ids_please/basic_spec.rb
@@ -4,7 +4,7 @@ describe IdsPlease do
 
   recognazible_links = %w(
       https://www.facebook.com/fb_acc
-      https://www.facebook.com/fb_acc2<U+200>
+      https://facebook.com/fb_acc2<U+200>
       http://instagram.com/inst_acc
       http://hi5.com/hi5_acc
       http://www.hi5.com/profile.html?uid=12341234


### PR DESCRIPTION
For a URL like `https://facebook.com/something`, I get `NoMethodError: undefined method encode for nil:NilClass` when I call the `grab` method. The commit here just calls `to_s` before the `encode` method in order to make sure that the it runs over a string.