### PR TITLE
Support Facebook pages that don't have entity_id

### DIFF
--- a/lib/ids_please/grabbers/facebook.rb
+++ b/lib/ids_please/grabbers/facebook.rb
@@ -27,7 +27,8 @@ class IdsPlease
       private
 
       def find_network_id
-        find_by_regex(/entity_id":"(\d+)"/) || find_by_regex(/al:ios:url" content="fb:\/\/page\/\?id=(\d+)"/)
+        find_by_regex(/entity_id":"(\d+)"/) || find_by_regex(/al:ios:url" content="fb:\/\/page\/\?id=(\d+)"/) ||
+        find_by_regex(/"pageID":"(\d+)"/)
       rescue => e
         record_error __method__, e.message
         return nil

--- a/lib/ids_please/grabbers/facebook.rb
+++ b/lib/ids_please/grabbers/facebook.rb
@@ -3,7 +3,7 @@ class IdsPlease
     class Facebook < IdsPlease::Grabbers::Base
 
       def grab_link
-        @network_id   = page_source.scan(/entity_id":"(\d+)"/).flatten.first
+        @network_id   = page_source.scan(/entity_id":"(\d+)"/).flatten.first ||page_source.scan(/al:ios:url" content="fb:\/\/page\/\?id=(\d+)"/).flatten.first
         @avatar       = page_source.scan(/og:image" content="([^"]+)"/).flatten.first
         @display_name = page_source.scan(/og:title" content="([^"]+)"/).flatten.first
         @username     = page_source.scan(/og:url" content="[^"]+\/([^\/"]+)"/).flatten.first

--- a/spec/ids_please/basic_spec.rb
+++ b/spec/ids_please/basic_spec.rb
@@ -173,6 +173,11 @@ describe IdsPlease do
         expect(@recognizer.parsed[:facebook]).to eq(['fb_acc', 'fb_acc2'])
       end
 
+      it 'get right id from facebook Arabic link' do
+        @recognizer = IdsPlease.new('https://www.facebook.com/%D8%A7%D9%84%D9%85%D8%B1%D9%83%D8%B2-%D8%A7%D9%84%D8%AB%D9%82%D8%A7%D9%81%D9%8A-%D8%A7%D9%84%D9%82%D8%A8%D8%B7%D9%8A-%D8%A7%D9%84%D8%A3%D8%B1%D8%AB%D9%88%D8%B0%D9%83%D8%B3%D9%8A-%D8%A8%D8%A7%D9%84%D9%85%D8%A7%D9%86%D9%8A%D8%A7-179240385797/')
+        expect(@recognizer.grab[:facebook].first.network_id).to eq('179240385797')
+      end
+
       it 'get right id from linkedin link' do
         expect(@recognizer.parsed[:linkedin]).to eq(['xnutsive', 'evil-martians', '12341234'])
       end


### PR DESCRIPTION
Some Facebook pages don't have `entity_id`, for example, the one I added to the automated test in the PR. In that case, I fallback to another metatag.