### PR TITLE
Fix detection of YouTube channel IDs

### DIFF
--- a/lib/ids_please/parsers/youtube.rb
+++ b/lib/ids_please/parsers/youtube.rb
@@ -6,7 +6,7 @@ class IdsPlease
 
       class << self
         def parse_link(link)
-          if link.path =~ /channels|user/
+          if link.path =~ /channel|user/
             link.path.split('/')[2]
           else
             link.path.split('/')[1]

--- a/spec/ids_please/basic_spec.rb
+++ b/spec/ids_please/basic_spec.rb
@@ -23,7 +23,7 @@ describe IdsPlease do
     https://plus.google.com/12341234
     https://plus.google.com/+VladimirBokov
     https://soundcloud.com/sc_acc
-    https://youtube.com/channels/yb_acc
+    https://youtube.com/channel/UCUZHFZ9jIKrLroW8LcyJEQQ
     http://tumblr-acc.tumblr.com
     http://odnoklassniki.com/profile/12341234/about
     http://ok.ru/profile/12341234/about
@@ -218,7 +218,7 @@ describe IdsPlease do
       end
 
       it 'get right id from youtube link' do
-        expect(@recognizer.parsed[:youtube].first).to eq('yb_acc')
+        expect(@recognizer.parsed[:youtube].first).to eq('UCUZHFZ9jIKrLroW8LcyJEQQ')
       end
 
       it 'get right id from ameba link' do


### PR DESCRIPTION
Apparently, YouTube channel URLs are (nowadays?) always formatted like `https://youtube.com/channel/...` which previously caused a `channel` username to be returned for such URLs.

This fixes the parser accordingly.