### PR TITLE
Detect facebook.com/pg pages

### DIFF
--- a/lib/ids_please/parsers/facebook.rb
+++ b/lib/ids_please/parsers/facebook.rb
@@ -12,6 +12,8 @@ class IdsPlease
             query['id'].first
           elsif link.path =~ /\/pages\//
             link.path.split('/').last
+          elsif link.path =~ /\/pg\//
+            link.path.split('/pg/')[1].split('/')[0]
           else
             link.path.split('/')[1]
           end

--- a/spec/ids_please/basic_spec.rb
+++ b/spec/ids_please/basic_spec.rb
@@ -4,6 +4,8 @@ describe IdsPlease do
   recognazible_links = %w(
     https://www.facebook.com/fb_acc
     https://facebook.com/fb_acc2<U+200>
+    https://www.facebook.com/pages/fb_pages_page
+    https://www.facebook.com/pg/fb_pg_page/posts
     http://instagram.com/inst_acc
     http://hi5.com/hi5_acc
     http://www.hi5.com/profile.html?uid=12341234
@@ -62,7 +64,7 @@ describe IdsPlease do
       end
 
       it 'recognizes facebook link' do
-        expect(@recognizer.recognized[:facebook].count).to eq(2)
+        expect(@recognizer.recognized[:facebook].count).to eq(4)
       end
 
       it 'recognizes hi5 link' do
@@ -165,7 +167,7 @@ describe IdsPlease do
       end
 
       it 'get right id from facebook link' do
-        expect(@recognizer.parsed[:facebook]).to eq(%w(fb_acc fb_acc2))
+        expect(@recognizer.parsed[:facebook]).to eq(%w(fb_acc fb_acc2 fb_pages_page fb_pg_page))
       end
 
       it 'get right id from facebook Arabic link' do


### PR DESCRIPTION
Facebook occasionally uses `/pg/` for URLs of vanity pages, like https://www.facebook.com/pg/Xataka/posts/

This adds support for such URLs.